### PR TITLE
Fix: Eliminate Visual Tab Jumping During Progressive Loading

### DIFF
--- a/app/components/SearchResults.tsx
+++ b/app/components/SearchResults.tsx
@@ -89,8 +89,9 @@ export default function SearchResults({ results, isLoading, searchQuery }: Searc
 
   // Calculate counts for each media type including streaming status
   const { movieCount, tvCount, notStreamingCount, filteredResults } = useMemo(() => {
-    // Don't filter until providers data is loaded
-    if (isLoadingProviders || Object.keys(providersData).length === 0) {
+    // Show results progressively as provider data becomes available
+    // Only require that we have at least some provider data OR loading is complete
+    if (isLoadingProviders && Object.keys(providersData).length === 0) {
       return {
         movieCount: 0,
         tvCount: 0,
@@ -105,13 +106,19 @@ export default function SearchResults({ results, isLoading, searchQuery }: Searc
       return providersData[key] || null;
     };
 
-    // Categorize all results by media type and streaming status
-    const allStreaming = results.results.filter(item => {
+    // Only categorize items that have provider data loaded
+    const itemsWithProviders = results.results.filter(item => {
+      const key = `${item.media_type}-${item.id}`;
+      return providersData.hasOwnProperty(key);
+    });
+
+    // Categorize loaded items by media type and streaming status
+    const allStreaming = itemsWithProviders.filter(item => {
       const providers = getItemProviders(item);
       return isStreamable(providers, 'US');
     });
 
-    const allNotStreaming = results.results.filter(item => {
+    const allNotStreaming = itemsWithProviders.filter(item => {
       const providers = getItemProviders(item);
       return !isStreamable(providers, 'US');
     });


### PR DESCRIPTION
## 🐛 Critical UX Bug Fixed

**Problem:** During progressive loading, results would visually 'jump' between tabs:
1. Items appear in 'Not Streaming' tab first
2. When provider data loads, they jump to correct 'Movies'/'TV' tabs
3. Creates jarring, unpredictable UX

**Root Cause:** 
- `isStreamable(null)` returns `false` for items without provider data yet
- Progressive loading updates caused constant reclassification

## ✅ Solution
- **Only show items with loaded provider data** instead of misclassifying them
- Items without provider data are excluded from filtering until their data arrives
- Enables smooth progressive loading without visual jumping
- Maintains accurate tab counts throughout loading process

## 🧪 Testing
- Search 'Star Wars' - no more tab jumping
- Search 'Batman' - smooth progressive loading  
- Tab counts accurately reflect only loaded items

## 📊 Impact
- Eliminates confusing visual jumping behavior
- Maintains progressive loading benefits
- More predictable, professional UX during franchise searches

**Critical fix for production deployment.**